### PR TITLE
Fix code 500 because of unsolvable path

### DIFF
--- a/templates/Log/index.html.twig
+++ b/templates/Log/index.html.twig
@@ -7,7 +7,7 @@
 {% block document %}
 <nav class="nav-internal">
     <ul>
-        <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appdossier_detailvoorlegger', {'dossierId': dossier.id}) }}"><i class="icon-arrow-left"></i><span>Terug naar dossier<span></a></li>
+        <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appdossier_index') }}" data-decorator="get-overview-state" data-context="dossier"><i class="icon-arrow-left"></i><span>Terug naar overzicht<span></a></li> 
     </ul>
 </nav>
     <div class="document well">


### PR DESCRIPTION
URL on a non-dossier-related page was pointing to a dossier; which is of course not set.