### PR TITLE
Feature/new roles

### DIFF
--- a/src/Controller/AppDossierController.php
+++ b/src/Controller/AppDossierController.php
@@ -4,6 +4,7 @@ namespace GemeenteAmsterdam\FixxxSchuldhulp\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Aantekening;
+use GemeenteAmsterdam\FixxxSchuldhulp\Entity\ActionEvent as ActionEventEntity;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Document;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Dossier;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\DossierDocument;
@@ -46,11 +47,10 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Workflow\Registry as WorkflowRegistry;
-use GemeenteAmsterdam\FixxxSchuldhulp\Entity\ActionEvent as ActionEventEntity;
 
 /**
  * @Route("/app/dossier")
- * @Security("has_role('ROLE_MADI') || has_role('ROLE_GKA') || has_role('ROLE_ADMIN')")
+ * @Security("has_role('ROLE_MADI') || has_role('ROLE_GKA') || has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_MADI_KEYUSER') || has_role('ROLE_ADMIN')")
  */
 class AppDossierController extends Controller
 {

--- a/src/Controller/AppGebruikerController.php
+++ b/src/Controller/AppGebruikerController.php
@@ -39,7 +39,7 @@ class AppGebruikerController extends Controller
 
                 break;
             case Gebruiker::TYPE_GKA_APPBEHEERDER:
-                $gebruikers = $repository->findAllByType([Gebruiker::TYPE_GKA, Gebruiker::TYPE_GKA_APPBEHEERDER], $request->query->getInt('page', 0), $request->query->getInt('pageSize', $maxPageSize));
+                $gebruikers = $repository->findAllByType([Gebruiker::TYPE_GKA, Gebruiker::TYPE_GKA_APPBEHEERDER, Gebruiker::TYPE_MADI, Gebruiker::TYPE_MADI_KEYUSER], $request->query->getInt('page', 0), $request->query->getInt('pageSize', $maxPageSize));
 
                 break;
 

--- a/src/Controller/AppGebruikerController.php
+++ b/src/Controller/AppGebruikerController.php
@@ -46,7 +46,7 @@ class AppGebruikerController extends Controller
 
     /**
      * @Route("/nieuw")
-     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_MADI_KEYUSER') || has_role('ROLE_ADMIN')")
      */
     public function createAction(Request $request, EntityManagerInterface $em)
     {
@@ -70,7 +70,7 @@ class AppGebruikerController extends Controller
 
     /**
      * @Route("/detail/{gebruikerId}/bewerken")
-     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_MADI_KEYUSER') || has_role('ROLE_ADMIN')")
      * @ParamConverter("gebruiker", options={"id"="gebruikerId"})
      */
     public function updateAction(Request $request, EntityManagerInterface $em, Gebruiker $gebruiker, EventDispatcherInterface $eventDispatcher, TokenStorageInterface $tokenStorage)

--- a/src/Controller/AppGebruikerController.php
+++ b/src/Controller/AppGebruikerController.php
@@ -46,7 +46,7 @@ class AppGebruikerController extends Controller
 
     /**
      * @Route("/nieuw")
-     * @Security("has_role('ROLE_APPBEHEER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      */
     public function createAction(Request $request, EntityManagerInterface $em)
     {
@@ -70,7 +70,7 @@ class AppGebruikerController extends Controller
 
     /**
      * @Route("/detail/{gebruikerId}/bewerken")
-     * @Security("has_role('ROLE_APPBEHEER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      * @ParamConverter("gebruiker", options={"id"="gebruikerId"})
      */
     public function updateAction(Request $request, EntityManagerInterface $em, Gebruiker $gebruiker, EventDispatcherInterface $eventDispatcher, TokenStorageInterface $tokenStorage)

--- a/src/Controller/AppGebruikerController.php
+++ b/src/Controller/AppGebruikerController.php
@@ -30,8 +30,25 @@ class AppGebruikerController extends Controller
         $repository = $em->getRepository(Gebruiker::class);
 
         $maxPageSize = 20;
+        /** @var Gebruiker $user */
+        $user = $this->getUser();
+        $gebruikers = '';
+        switch ($user->getType()) {
+            case Gebruiker::TYPE_MADI_KEYUSER:
+                $gebruikers = $repository->findAllByType([Gebruiker::TYPE_MADI, Gebruiker::TYPE_MADI_KEYUSER], $request->query->getInt('page', 0), $request->query->getInt('pageSize', $maxPageSize));
 
-        $gebruikers = $repository->findAll($request->query->getInt('page', 0), $request->query->getInt('pageSize', $maxPageSize));
+                break;
+            case Gebruiker::TYPE_GKA_APPBEHEERDER:
+                $gebruikers = $repository->findAllByType([Gebruiker::TYPE_GKA, Gebruiker::TYPE_GKA_APPBEHEERDER], $request->query->getInt('page', 0), $request->query->getInt('pageSize', $maxPageSize));
+
+                break;
+
+            case Gebruiker::TYPE_ADMIN:
+                $gebruikers = $repository->findAll($request->query->getInt('page', 0), $request->query->getInt('pageSize', $maxPageSize));
+
+                break;
+        }
+
 
         return $this->render('Gebruiker/index.html.twig', [
             'gebruikers' => $gebruikers,

--- a/src/Controller/AppSchuldeiserController.php
+++ b/src/Controller/AppSchuldeiserController.php
@@ -1,33 +1,21 @@
 <?php
+
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Dossier;
-use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Voorlegger;
-use GemeenteAmsterdam\FixxxSchuldhulp\Repository\DossierRepository;
-use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\CreateDossierFormType;
-use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\DetailDossierFormType;
-use GemeenteAmsterdam\FixxxSchuldhulp\Entity\DossierDocument;
-use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\DossierDocumentFormType;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Form\FormError;
-use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Document;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Schuldeiser;
-use GemeenteAmsterdam\FixxxSchuldhulp\Repository\SchuldeiserRepository;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\SchuldeiserFormType;
+use GemeenteAmsterdam\FixxxSchuldhulp\Repository\SchuldeiserRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @Route("/app/schuldeiser")
- * @Security("has_role('ROLE_MADI') || has_role('ROLE_GKA') || has_role('ROLE_ADMIN')")
+ * @Security("has_role('ROLE_MADI') || has_role('ROLE_GKA') || has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_MADI_KEYUSER') || has_role('ROLE_ADMIN')")
  */
 class AppSchuldeiserController extends Controller
 {
@@ -62,7 +50,7 @@ class AppSchuldeiserController extends Controller
 
     /**
      * @Route("/nieuw")
-     * @Security("has_role('ROLE_GKA') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA') || has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      */
     public function createAction(Request $request, EntityManagerInterface $em)
     {
@@ -94,7 +82,7 @@ class AppSchuldeiserController extends Controller
 
     /**
      * @Route("/detail/{schuldeiserId}/bewerken")
-     * @Security("has_role('ROLE_GKA') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA') || has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      * @ParamConverter("schuldeiser", options={"id"="schuldeiserId"})
      */
     public function updateAction(Request $request, EntityManagerInterface $em, Schuldeiser $schuldeiser)

--- a/src/Controller/AppSchuldhulpbureauController.php
+++ b/src/Controller/AppSchuldhulpbureauController.php
@@ -1,15 +1,15 @@
 <?php
+
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Doctrine\ORM\EntityManagerInterface;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Schuldhulpbureau;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\SchuldhulpbureauFormType;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @Route("/app/schuldhulpbureau")
@@ -42,7 +42,7 @@ class AppSchuldhulpbureauController extends Controller
 
     /**
      * @Route("/nieuw")
-     * @Security("has_role('ROLE_APPBEHEER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      */
     public function createAction(Request $request, EntityManagerInterface $em)
     {
@@ -65,7 +65,7 @@ class AppSchuldhulpbureauController extends Controller
 
     /**
      * @Route("/detail/{schuldhulpbureauId}/bewerken")
-     * @Security("has_role('ROLE_APPBEHEER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      * @ParamConverter("schuldhulpbureau", options={"id"="schuldhulpbureauId"})
      */
     public function updateAction(Request $request, EntityManagerInterface $em, Schuldhulpbureau $schuldhulpbureau)

--- a/src/Controller/AppTeamController.php
+++ b/src/Controller/AppTeamController.php
@@ -1,18 +1,15 @@
 <?php
+
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Doctrine\ORM\EntityManagerInterface;
-use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Gebruiker;
-use GemeenteAmsterdam\FixxxSchuldhulp\Repository\GebruikerRepository;
-use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\GebruikerFormType;
 use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Team;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\TeamFormType;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @Route("/app/team")
@@ -45,7 +42,7 @@ class AppTeamController extends Controller
 
     /**
      * @Route("/nieuw")
-     * @Security("has_role('ROLE_APPBEHEER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      */
     public function createAction(Request $request, EntityManagerInterface $em)
     {
@@ -68,7 +65,7 @@ class AppTeamController extends Controller
 
     /**
      * @Route("/detail/{teamId}/bewerken")
-     * @Security("has_role('ROLE_APPBEHEER') || has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_GKA_APPBEHEERDER') || has_role('ROLE_ADMIN')")
      * @ParamConverter("team", options={"id"="teamId"})
      */
     public function updateAction(Request $request, EntityManagerInterface $em, Team $team)

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -1,13 +1,11 @@
 <?php
+
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends Controller
 {
@@ -25,7 +23,7 @@ class DefaultController extends Controller
      */
     public function appRedirectAction(Request $request)
     {
-        if ($this->isGranted('ROLE_APPBEHEER')) {
+        if ($this->isGranted('ROLE_GKA_APPBEHEERDER')) {
             return $this->redirectToRoute('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_index');
         }
         return $this->redirectToRoute('gemeenteamsterdam_fixxxschuldhulp_appdossier_index');

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -343,15 +343,27 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
      */
     public static function getTypes(string $type = null)
     {
-        $defaultTypes = [
-            'GKA - App Beheerder' => self::TYPE_GKA_APPBEHEERDER,
-            'GKA - Dossierbehandelaar' => self::TYPE_GKA,
-            'Madi - Key user' => self::TYPE_MADI_KEYUSER,
-            'Madi - Dossierbehandelaar' => self::TYPE_MADI,
-            ucfirst(self::TYPE_ONBEKEND) => self::TYPE_ONBEKEND
-        ];
-        if ($type === self::TYPE_ADMIN) {
-            $defaultTypes[ucfirst(self::TYPE_ADMIN)] = self::TYPE_ADMIN;
+        $defaultTypes = [];
+        switch ($type) {
+            case self::TYPE_MADI_KEYUSER:
+                $defaultTypes['Madi']['Madi - Dossierbehandelaar'] = self::TYPE_MADI;
+                $defaultTypes['Madi']['Madi - Key User'] = self::TYPE_MADI_KEYUSER;
+                break;
+
+            case self::TYPE_GKA_APPBEHEERDER:
+                $defaultTypes['GKA']['GKA - Dossierbehandelaar'] = self::TYPE_GKA;
+                $defaultTypes['GKA']['GKA - App Beheerder'] = self::TYPE_GKA_APPBEHEERDER;
+                break;
+
+            case self::TYPE_ADMIN:
+                $defaultTypes['Applicatie'][ucfirst(self::TYPE_ADMIN)] = self::TYPE_ADMIN;
+                $defaultTypes['Applicatie'][ucfirst(self::TYPE_ONBEKEND)] = self::TYPE_ONBEKEND;
+                $defaultTypes['GKA']['GKA - Dossierbehandelaar'] = self::TYPE_GKA;
+                $defaultTypes['GKA']['GKA - App Beheerder'] = self::TYPE_GKA_APPBEHEERDER;
+                $defaultTypes['Madi']['Madi - Dossierbehandelaar'] = self::TYPE_MADI;
+                $defaultTypes['Madi']['Madi - Key User'] = self::TYPE_MADI_KEYUSER;
+
+                break;
         }
         return $defaultTypes;
     }

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -29,7 +29,6 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
     const TYPE_MADI = 'madi';
     const TYPE_MADI_KEYUSER = 'madi_keyuser';
 
-    const TYPE_APPBEHEERDER = 'appbeheer';
     const TYPE_ONBEKEND = 'onbekend';
 
     /**
@@ -349,7 +348,6 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
             'GKA - Dossierbehandelaar' => self::TYPE_GKA,
             'Madi - Key user' => self::TYPE_MADI_KEYUSER,
             'Madi - Dossierbehandelaar' => self::TYPE_MADI,
-            ucfirst(self::TYPE_APPBEHEERDER) => self::TYPE_APPBEHEERDER,
             ucfirst(self::TYPE_ONBEKEND) => self::TYPE_ONBEKEND
         ];
         if ($type === self::TYPE_ADMIN) {

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -356,6 +356,7 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
                 break;
 
             case self::TYPE_ADMIN:
+            case 'ALL_TYPES':
                 $defaultTypes['Applicatie'][ucfirst(self::TYPE_ADMIN)] = self::TYPE_ADMIN;
                 $defaultTypes['Applicatie'][ucfirst(self::TYPE_ONBEKEND)] = self::TYPE_ONBEKEND;
                 $defaultTypes['GKA']['GKA - Dossierbehandelaar'] = self::TYPE_GKA;
@@ -366,6 +367,18 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
                 break;
         }
         return $defaultTypes;
+    }
+
+    /**
+     * Return the human readable title matching giving Gebruiker::TYPE.
+     *
+     * @param string $type
+     *
+     * @return string
+     */
+    public static function getTitleFromType(string $type): string
+    {
+        return array_search($type, array_merge(...array_values(self::getTypes('ALL_TYPES'))));
     }
 
     /**

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -2,14 +2,14 @@
 
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Serializable;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
-use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * @ORM\Entity(repositoryClass="GemeenteAmsterdam\FixxxSchuldhulp\Repository\GebruikerRepository")
@@ -21,13 +21,14 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, EquatableInterface
 {
-    const TYPE_GKA = 'gka';
-    const TYPE_MADI = 'madi';
+    const TYPE_ADMIN = 'admin';
 
+    const TYPE_GKA = 'gka';
     const TYPE_GKA_APPBEHEERDER = 'gka_appbeheerder';
+
+    const TYPE_MADI = 'madi';
     const TYPE_MADI_KEYUSER = 'madi_keyuser';
 
-    const TYPE_ADMIN = 'admin';
     const TYPE_APPBEHEERDER = 'appbeheer';
     const TYPE_ONBEKEND = 'onbekend';
 
@@ -67,7 +68,7 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
 
     /**
      * @var string
-     * @ORM\Column(type="string", length=10, nullable=false)
+     * @ORM\Column(type="string", length=100, nullable=false)
      * @Assert\NotBlank
      * @Assert\Choice(callback="getTypes")
      */
@@ -207,7 +208,7 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
 
     public function setType($type)
     {
-        $this->type = strtolower(str_replace(' ','_', $type));
+        $this->type = strtolower(str_replace(' ', '_', $type));
     }
 
     public function setNaam($naam)
@@ -338,15 +339,16 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
 
     /**
      * @param string $type
+     *
      * @return string[]
      */
     public static function getTypes(string $type = null)
     {
         $defaultTypes = [
-            'MADI - Dossierbehandelaar' => self::TYPE_MADI,
-            'GKA - Dossierbehandelaar' => self::TYPE_GKA,
             'GKA - App Beheerder' => self::TYPE_GKA_APPBEHEERDER,
+            'GKA - Dossierbehandelaar' => self::TYPE_GKA,
             'Madi - Key user' => self::TYPE_MADI_KEYUSER,
+            'Madi - Dossierbehandelaar' => self::TYPE_MADI,
             ucfirst(self::TYPE_APPBEHEERDER) => self::TYPE_APPBEHEERDER,
             ucfirst(self::TYPE_ONBEKEND) => self::TYPE_ONBEKEND
         ];

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -353,6 +353,8 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
             case self::TYPE_GKA_APPBEHEERDER:
                 $defaultTypes['GKA']['GKA - Dossierbehandelaar'] = self::TYPE_GKA;
                 $defaultTypes['GKA']['GKA - App Beheerder'] = self::TYPE_GKA_APPBEHEERDER;
+                $defaultTypes['Madi']['Madi - Dossierbehandelaar'] = self::TYPE_MADI;
+                $defaultTypes['Madi']['Madi - Key User'] = self::TYPE_MADI_KEYUSER;
                 break;
 
             case self::TYPE_ADMIN:

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -23,6 +23,10 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
 {
     const TYPE_GKA = 'gka';
     const TYPE_MADI = 'madi';
+
+    const TYPE_GKA_APPBEHEERDER = 'gka_appbeheerder';
+    const TYPE_MADI_KEYUSER = 'madi_keyuser';
+
     const TYPE_ADMIN = 'admin';
     const TYPE_APPBEHEERDER = 'appbeheer';
     const TYPE_ONBEKEND = 'onbekend';
@@ -339,8 +343,10 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
     public static function getTypes(string $type = null)
     {
         $defaultTypes = [
-            'Dossierbehandelaar MADI' => self::TYPE_MADI,
-            'Dossierbehandelaar GKA' => self::TYPE_GKA,
+            'MADI - Dossierbehandelaar' => self::TYPE_MADI,
+            'GKA - Dossierbehandelaar' => self::TYPE_GKA,
+            'GKA - App Beheerder' => self::TYPE_GKA_APPBEHEERDER,
+            'Madi - Key user' => self::TYPE_MADI_KEYUSER,
             ucfirst(self::TYPE_APPBEHEERDER) => self::TYPE_APPBEHEERDER,
             ucfirst(self::TYPE_ONBEKEND) => self::TYPE_ONBEKEND
         ];

--- a/src/Migrations/Version20190217170132.php
+++ b/src/Migrations/Version20190217170132.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190217170132 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE gebruiker ALTER type TYPE VARCHAR(100)');
+        $this->addSql('UPDATE gebruiker SET type = \'gka_appbeheerder\' WHERE type = \'appbeheer\';');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('UPDATE gebruiker SET type = \'appbeheer\' WHERE type = \'gka_appbeheerder\';');
+        $this->addSql('ALTER TABLE gebruiker ALTER type TYPE VARCHAR(10)');
+    }
+}

--- a/src/Repository/GebruikerRepository.php
+++ b/src/Repository/GebruikerRepository.php
@@ -1,14 +1,45 @@
 <?php
+
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Repository;
 
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 
+/**
+ * Class GebruikerRepository
+ *
+ * @package GemeenteAmsterdam\FixxxSchuldhulp\Repository
+ */
 class GebruikerRepository extends EntityRepository
 {
-    public function findAll($page = 0, $pageSize = 100)
+    /**
+     * @param int $page
+     * @param int $pageSize
+     *
+     * @return Paginator
+     */
+    public function findAll($page = 0, $pageSize = 100): Paginator
     {
         $qb = $this->createQueryBuilder('gebruiker');
+        $qb->orderBy('gebruiker.username', 'ASC');
+        $qb->setFirstResult($page * $pageSize);
+        $qb->setMaxResults($pageSize);
+
+        return new Paginator($qb->getQuery());
+    }
+
+    /**
+     * @param array $type
+     * @param int   $page
+     * @param int   $pageSize
+     *
+     * @return Paginator
+     */
+    public function findAllByType(array $type, int $page = 0, int $pageSize = 100): Paginator
+    {
+        $qb = $this->createQueryBuilder('gebruiker');
+        $qb->andWhere('gebruiker.type IN (:type)');
+        $qb->setParameter('type', $type);
         $qb->orderBy('gebruiker.username', 'ASC');
         $qb->setFirstResult($page * $pageSize);
         $qb->setMaxResults($pageSize);

--- a/src/Twig/GebruikerTypeToTitleExtension.php
+++ b/src/Twig/GebruikerTypeToTitleExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GemeenteAmsterdam\FixxxSchuldhulp\Twig;
+
+use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Gebruiker;
+
+/**
+ * Class GebruikerTypeToTitleExtension
+ *
+ * @package GemeenteAmsterdam\FixxxSchuldhulp\Twig
+ */
+class GebruikerTypeToTitleExtension extends \Twig_Extension
+{
+    /**
+     * @return array|\Twig_Filter[]s
+     */
+    public function getFilters(): array
+    {
+        return [
+            new \Twig_Filter('transform_type_in_title', function (String $type) {
+                return Gebruiker::getTitleFromType($type);
+            })
+        ];
+    }
+
+}

--- a/templates/Dossier/index.html.twig
+++ b/templates/Dossier/index.html.twig
@@ -59,7 +59,7 @@
                 </div>
                 <div class="columns">
                     <div class="column">
-                        {% if is_granted('ROLE_MADI') is same as(FALSE) %}
+                        {% if is_granted('ROLE_MADI') is same as(FALSE) or is_granted('ROLE_MADI_KEYUSER') is same as(FALSE) %}
                             {{ form_row(searchForm.schuldhulpbureaus) }}
                         {% endif %}
                         {{ form_row(searchForm.medewerkerSchuldhulpbureau) }}

--- a/templates/Dossier/index.html.twig
+++ b/templates/Dossier/index.html.twig
@@ -59,7 +59,7 @@
                 </div>
                 <div class="columns">
                     <div class="column">
-                        {% if is_granted('ROLE_MADI') is same as(FALSE) or is_granted('ROLE_MADI_KEYUSER') is same as(FALSE) %}
+                        {% if is_granted('ROLE_MADI') is same as(FALSE) %}
                             {{ form_row(searchForm.schuldhulpbureaus) }}
                         {% endif %}
                         {{ form_row(searchForm.medewerkerSchuldhulpbureau) }}

--- a/templates/Gebruiker/index.html.twig
+++ b/templates/Gebruiker/index.html.twig
@@ -12,11 +12,11 @@
             <nav class="nav-internal">
                 <ul>
                     <li>Gebruikers</li>
-                    {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_create') }}">Nieuwe gebruiker</a></li>{% endif %}
+                    {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_MADI_KEYUSER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_create') }}">Nieuwe gebruiker</a></li>{% endif %}
                 </ul>
             </nav>
         </div>
-        {% if is_granted('ROLE_GKA_APPBEHEERDER') == false and is_granted('ROLE_ADMIN') == false %}
+        {% if is_granted('ROLE_GKA_APPBEHEERDER') == false and is_granted('ROLE_MADI_KEYUSER') == false and is_granted('ROLE_ADMIN') == false %}
             <p>Alleen applicatie beheerders kunnen nieuwe gebruikers toevoegen en bestaande gebruikers wijzigen</p>
         {% endif %}
         <div class="table">
@@ -33,9 +33,9 @@
                 </thead>
                 <tbody>
 {% for gebruiker in gebruikers %}
-                    <tr{% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
+                    <tr{% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_MADI_KEYUSER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
                         <th>
-                            {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}
+                            {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_MADI_KEYUSER') or is_granted('ROLE_ADMIN') %}
                                 <a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_update', {'gebruikerId': gebruiker.id}) }}">{{ gebruiker.username }}</a>
                             {% else %}
                                 {{ gebruiker.username }}

--- a/templates/Gebruiker/index.html.twig
+++ b/templates/Gebruiker/index.html.twig
@@ -12,11 +12,11 @@
             <nav class="nav-internal">
                 <ul>
                     <li>Gebruikers</li>
-                    {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_create') }}">Nieuwe gebruiker</a></li>{% endif %}
+                    {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_create') }}">Nieuwe gebruiker</a></li>{% endif %}
                 </ul>
             </nav>
         </div>
-        {% if is_granted('ROLE_APPBEHEER') == false and is_granted('ROLE_ADMIN') == false %}
+        {% if is_granted('ROLE_GKA_APPBEHEERDER') == false and is_granted('ROLE_ADMIN') == false %}
             <p>Alleen applicatie beheerders kunnen nieuwe gebruikers toevoegen en bestaande gebruikers wijzigen</p>
         {% endif %}
         <div class="table">
@@ -33,9 +33,9 @@
                 </thead>
                 <tbody>
 {% for gebruiker in gebruikers %}
-                    <tr{% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
+                    <tr{% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
                         <th>
-                            {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}
+                            {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}
                                 <a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_update', {'gebruikerId': gebruiker.id}) }}">{{ gebruiker.username }}</a>
                             {% else %}
                                 {{ gebruiker.username }}

--- a/templates/Gebruiker/index.html.twig
+++ b/templates/Gebruiker/index.html.twig
@@ -44,10 +44,7 @@
                         <td>{{ gebruiker.naam }}</td>
                         <td>{{ gebruiker.email }}</td>
                         <td>
-                            {% if gebruiker.type in ['madi', 'gka'] %}
-                                Dossierbehandelaar
-                            {% endif %}
-                            {{ gebruiker.type|capitalize }}
+                            {{ gebruiker.type|transform_type_in_title }}
                         </td>
                         <td>{{ gebruiker.teamGka }}</td>
                         <td>{{ gebruiker.schuldhulpbureaus|join(', ') }}</td>

--- a/templates/Schuldeiser/index.html.twig
+++ b/templates/Schuldeiser/index.html.twig
@@ -12,11 +12,11 @@
             <nav class="nav-internal">
                 <ul>
                     <li>Schuldeisers</li>
-                    {% if is_granted('ROLE_GKA') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldeiser_create') }}">Nieuwe schuldeiser</a></li>{% endif %}
+                    {% if is_granted('ROLE_GKA') or is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldeiser_create') }}">Nieuwe schuldeiser</a></li>{% endif %}
                 </ul>
             </nav>
         </div>
-        {% if is_granted('ROLE_GKA') == false and is_granted('ROLE_ADMIN') == false %}
+        {% if is_granted('ROLE_GKA') == false and is_granted('ROLE_ADMIN') == false and is_granted('ROLE_GKA_APPBEHEERDER') %}
             <p>Alleen medewerkers van het GKA kunnen schuldeisers toevoegen of wijzigen.</p>
         {% endif %}
         <div class="table">
@@ -29,9 +29,9 @@
                 </thead>
                 <tbody>
 {% for schuldeiser in schuldeisers %}
-                    <tr{% if is_granted('ROLE_GKA') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
+                    <tr{% if is_granted('ROLE_GKA') or is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
                         <th>
-                            {% if is_granted('ROLE_GKA') or is_granted('ROLE_ADMIN') %}
+                            {% if is_granted('ROLE_GKA') or is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}
                                 <a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldeiser_update', {'schuldeiserId': schuldeiser.id}) }}">{{ schuldeiser.bedrijfsnaam }}</a>
                             {% else %}
                                 {{ schuldeiser.bedrijfsnaam }}

--- a/templates/Schuldhulpbureau/index.html.twig
+++ b/templates/Schuldhulpbureau/index.html.twig
@@ -12,11 +12,11 @@
             <nav class="nav-internal">
                 <ul>
                     <li>Schuldhulpbureaus</li>
-                    {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldhulpbureau_create') }}">Nieuw schuldhulpbureau</a></li>{% endif %}
+                    {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldhulpbureau_create') }}">Nieuw schuldhulpbureau</a></li>{% endif %}
                 </ul>
             </nav>
         </div>
-        {% if is_granted('ROLE_APPBEHEER') == false and is_granted('ROLE_ADMIN') == false %}
+        {% if is_granted('ROLE_GKA_APPBEHEERDER') == false and is_granted('ROLE_ADMIN') == false %}
             <p>Alleen applicatie beheerders kunnen nieuwe schuldhulpbureaus toevoegen en bestaande schuldhulpbureaus wijzigen</p>
         {% endif %}
         <div class="table">
@@ -29,9 +29,9 @@
                 </thead>
                 <tbody>
 {% for schuldhulpbureau in schuldhulpbureaus %}
-                    <tr{% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
+                    <tr{% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
                         <th>
-                            {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}
+                            {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}
                                 <a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldhulpbureau_update', {'schuldhulpbureauId': schuldhulpbureau.id}) }}">{{ schuldhulpbureau.naam }}</a>
                             {% else %}
                                 {{ schuldhulpbureau.naam }}

--- a/templates/Team/index.html.twig
+++ b/templates/Team/index.html.twig
@@ -12,11 +12,11 @@
             <nav class="nav-internal">
                 <ul>
                     <li>Teams</li>
-                    {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appteam_create') }}">Nieuw team</a></li>{% endif %}
+                    {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}<li><a class="primary" href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appteam_create') }}">Nieuw team</a></li>{% endif %}
                 </ul>
             </nav>
         </div>
-        {% if is_granted('ROLE_APPBEHEER') == false and is_granted('ROLE_ADMIN') == false %}
+        {% if is_granted('ROLE_GKA_APPBEHEERDER') == false and is_granted('ROLE_ADMIN') == false %}
             <p>Alleen applicatie beheerders kunnen nieuwe teams toevoegen en bestaande teams wijzigen</p>
         {% endif %}
         <div class="table">
@@ -29,9 +29,9 @@
                 </thead>
                 <tbody>
 {% for team in teams %}
-                    <tr{% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
+                    <tr{% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %} class="row-link"{% endif %}>
                         <th>
-                            {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}
+                            {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}
                                 <a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appteam_update', {'teamId': team.id}) }}">{{ team.naam }}</a>
                             {% else %}
                                 {{ team.naam }}

--- a/templates/master.html.twig
+++ b/templates/master.html.twig
@@ -25,7 +25,7 @@
         <link type="text/css" rel="stylesheet" href="//fast.fonts.net/cssapi/0037f97b-b0f6-41de-8f33-75b12c9f76ea.css"/>
     </head>
     <body class="{% block body_classes %}{% endblock %}" data-decorator="restore-splitter" data-version-date="{{ app_version.getVersionDate }}">
-      
+
         {% block pdfsplitter %}
           <aside id="pdfsplitter" class="pdf-splitter no-header file-pdf-pages" data-decorator="droppable" data-changer="pdfsplitter">
               <div class="pages"></div>
@@ -73,14 +73,14 @@
                 <nav class="nav">
                   <ul class="menu">
                       {% block navigation_menu %}
-                    {% if is_granted('ROLE_MADI') or is_granted('ROLE_GKA') or is_granted('ROLE_ADMIN') %}
+                    {% if is_granted('ROLE_MADI') or is_granted('ROLE_GKA') or is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_MADI_KEYUSER') or is_granted('ROLE_ADMIN') %}
                         <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appdossier_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_appdossier_') %} class="active"{% endif %}>Dossiers</a></li>
                         <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldeiser_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_appschuldeiser_') %} class="active"{% endif %}>Schuldeisers</a></li>
                     {% endif %}
                     <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appschuldhulpbureau_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_appschuldhulpbureau_') %} class="active"{% endif %}>Schuldhulpbureaus</a></li>
                     <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appteam_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_appteam_') %} class="active"{% endif %}>Teams</a></li>
                     <li class="divider"><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appgebruiker_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_appgebruiker_') %} class="active"{% endif %}>Gebruikers</a></li>
-                    {% if is_granted('ROLE_APPBEHEER') or is_granted('ROLE_ADMIN') %}
+                    {% if is_granted('ROLE_GKA_APPBEHEERDER') or is_granted('ROLE_ADMIN') %}
                         <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_applog_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_applog_') %} class="active"{% endif %}>Logs</a></li>
                     {% endif %}
                     <li><a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_userreleasenotes_index') }}"{% if (app.request.attributes.get('_route') starts with 'gemeenteamsterdam_fixxxschuldhulp_userreleasenotes_') %} class="active"{% endif %}>Versies</a></li>
@@ -96,7 +96,7 @@
                 {% endif %}
               </div>
         </header>
-        
+
         <div class="{% block documentContainerClass %}document-container{% endblock %}">
 
 {% for type, messages in app.flashes %}


### PR DESCRIPTION
Gebruikersrollen zijn nu:
- ROLE_ADMIN 
- ROLE_GKA 
- ROLE_GKA_APPBEHEERDER 
- ROLE_MADI 
- ROLE_MADI_KEYUSER 
- ROLE_ONBEKEND 

**LET OP: ROLE_APPBEHEER is dus vervangen met ROLE_GKA_APPBEHEERDER**

Gka beschikt nu dus over **GKA - App Beheerder**:
Kan nieuwe gebruikers aanmaken voor **ALLE** schuldhulpbureaus, en de volgende rollen toekennen:
- ROLE_GKA 
- ROLE_GKA_APPBEHEERDER 
- ROLE_MADI 
- ROLE_MADI_KEYUSER 

Madi beschikt nu over **Madi - Key User**:
Kan nieuwe gebruikers aanmaken voor **ALLEEN** schuldhulpbureaus waar de Madi aan is **GEKOPPELD**, en de volgende rollen toekennen: 
- ROLE_MADI 
- ROLE_MADI_KEYUSER 

**Admin** kan en ziet alles.

![image](https://user-images.githubusercontent.com/4005934/52918370-705d0a00-32f6-11e9-8db3-19804670d427.png)

Gebruikersoverzicht houdt nu ook rekening met je welke type user er is ingelogd. 


Issues:
1. Type onbekend heeft geen schuldhulpbureau of type GKA/Madi, dus we kunnen niet bepalen in welke lijst deze wel/niet getoond kan worden.

To do:
- [ ] Type onbekend zichtbaar maken zodra interne issue 1 is opgelost.
- [ ] Gebruikersoverzicht afstemmen op niet alleen type, maar ook schuldhulpbureau voor ingelogde madi.