### PR TITLE
Added dropdown for Madi Keyuser, Gka Appbeheerder and Admin to be able to change dossier to a certain status.

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -1060,8 +1060,11 @@
         newDocCounter = 1,
         i;
 
-
-      e && e.preventDefault();
+      if (form.querySelector('#change_dossier_status_status') && form.querySelector('#change_dossier_status_status').value !== form.querySelector('#change_dossier_status_status').dataset.current){
+        w.onbeforeunload = function () {}
+      }else {
+        e && e.preventDefault();
+      }
 
       form && changers[form.dataset.changer].call(form, e);
       if (form.classList.contains('invalid')){

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -1061,7 +1061,8 @@
         i;
 
       if (form.querySelector('#change_dossier_status_status') && form.querySelector('#change_dossier_status_status').value !== form.querySelector('#change_dossier_status_status').dataset.current){
-        w.onbeforeunload = function () {}
+        w.onbeforeunload = function () {};
+        return;
       }else {
         e && e.preventDefault();
       }

--- a/src/Controller/AppDossierController.php
+++ b/src/Controller/AppDossierController.php
@@ -242,7 +242,7 @@ class AppDossierController extends Controller
         $changeDossierStatusForm = false;
 
 
-        if (!$dossier->isInPrullenbak() && !$dossier->isAfgesloten()) {
+        if (!$dossier->isInPrullenbak()) {
             if (
                 $this->getUser()->isApplicationAdmin()
                 ||

--- a/src/Controller/AppDossierController.php
+++ b/src/Controller/AppDossierController.php
@@ -16,6 +16,7 @@ use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Voorlegger;
 use GemeenteAmsterdam\FixxxSchuldhulp\Event\ActionEvent;
 use GemeenteAmsterdam\FixxxSchuldhulp\Event\DossierAddedAantekeningEvent;
 use GemeenteAmsterdam\FixxxSchuldhulp\Event\DossierChangedEvent;
+use GemeenteAmsterdam\FixxxSchuldhulp\Form\ChangeDossierStatusType;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\CreateAantekeningFormType;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\CreateDossierFormType;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\DetailDossierFormType;
@@ -238,6 +239,24 @@ class AppDossierController extends Controller
             $eventDispatcher->dispatch(DossierChangedEvent::NAME, new DossierChangedEvent($dossier, $this->getUser()));
             $voorleggerForm = $this->createForm(VoorleggerFormType::class, $dossier->getVoorlegger());
         }
+        $changeDossierStatusForm = false;
+
+
+        if (!$dossier->isInPrullenbak() && !$dossier->isAfgesloten()) {
+            if (
+                $this->getUser()->isApplicationAdmin()
+                ||
+                ($dossier->withMadi() && $this->getUser()->isMadiKeyUser())
+                ||
+                ($dossier->withGka() && $this->getUser()->isGkaAppBeheerder())
+            ) {
+                $changeDossierStatusForm = $this->createForm(ChangeDossierStatusType::class, $dossier, [
+                    'disabled' => $dossier->isInPrullenbak() === true,
+                ]);
+                $changeDossierStatusForm->handleRequest($request);
+            }
+        }
+
 
         $workflow = $registry->get($dossier);
 
@@ -246,6 +265,7 @@ class AppDossierController extends Controller
         return $this->render('Dossier/detailVoorlegger.html.twig', [
             'dossier' => $dossier,
             'voorleggerForm' => $voorleggerForm->createView(),
+            'changeDossierStatusForm' => $changeDossierStatusForm !== false ? $changeDossierStatusForm->createView() : false
         ]);
     }
 

--- a/src/Entity/Dossier.php
+++ b/src/Entity/Dossier.php
@@ -2,10 +2,10 @@
 
 namespace GemeenteAmsterdam\FixxxSchuldhulp\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="GemeenteAmsterdam\FixxxSchuldhulp\Repository\DossierRepository")
@@ -15,6 +15,14 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class Dossier
 {
+    public const STATUS_BEZIG_MADI = 'bezig_madi';
+    public const STATUS_COMPLEET_MADI = 'compleet_madi';
+    public const STATUS_GECONTROLEERD_MADI = 'gecontroleerd_madi';
+    public const STATUS_VERZONDEN_MADI = 'verzonden_madi';
+    public const STATUS_COMPLEET_GKA = 'compleet_gka';
+    public const STATUS_DOSSIER_GECONTROLEERD_GKA = 'dossier_gecontroleerd_gka';
+    public const STATUS_AFGESLOTEN_GKA = 'afgesloten_gka';
+
     /**
      * @var integer
      * @ORM\Id
@@ -329,6 +337,7 @@ class Dossier
 
     /**
      * @param string $onderwerp
+     *
      * @return \GemeenteAmsterdam\FixxxSchuldhulp\Entity\DossierDocument[]|\Doctrine\Common\Collections\ArrayCollection
      */
     public function getDocumentenByOnderwerp($onderwerp)
@@ -340,6 +349,7 @@ class Dossier
 
     /**
      * @param string $onderwerp
+     *
      * @return \GemeenteAmsterdam\FixxxSchuldhulp\Entity\DossierDocument[]|\Doctrine\Common\Collections\ArrayCollection
      */
     public function getNietVerwijderdeDocumentenByOnderwerp($onderwerp)
@@ -351,6 +361,7 @@ class Dossier
 
     /**
      * @param Array $onderwerpen
+     *
      * @return \GemeenteAmsterdam\FixxxSchuldhulp\Entity\DossierDocument[]|\Doctrine\Common\Collections\ArrayCollection
      */
     public function getNietVerwijderdeDocumentenByOnderwerpen($onderwerpen)
@@ -362,6 +373,7 @@ class Dossier
 
     /**
      * @param integer $id
+     *
      * @return NULL|DossierDocument
      */
     public function getDossierDocumentByDocumentId($id)
@@ -374,6 +386,7 @@ class Dossier
 
     /**
      * @param integer $id
+     *
      * @return NULL|DossierDocument
      */
     public function getDossierDocumentByDossierDocumentId($id)
@@ -515,5 +528,42 @@ class Dossier
         }
     }
 
+    /**
+     * Based on current status we can determine whether a dossier is with a MaDi organisation
+     *
+     * @return bool
+     */
+    public function withMadi(): bool
+    {
+        return in_array($this->getStatus(), [
+            self::STATUS_BEZIG_MADI,
+            self::STATUS_COMPLEET_MADI,
+            self::STATUS_GECONTROLEERD_MADI,
+        ], true);
+    }
 
+    /**
+     * Based on current status we can determine whether a dossier is with the GKA
+     *
+     * @return bool
+     */
+    public function withGka(): bool
+    {
+        return in_array($this->getStatus(), [
+            self::STATUS_VERZONDEN_MADI,
+            self::STATUS_COMPLEET_GKA,
+            self::STATUS_DOSSIER_GECONTROLEERD_GKA,
+            self::STATUS_AFGESLOTEN_GKA,
+        ], true);
+    }
+
+    /**
+     * Checks whether the current dossier is closed based on status.
+     *
+     * @return bool
+     */
+    public function isAfgesloten(): bool
+    {
+        return $this->getStatus() === self::STATUS_AFGESLOTEN_GKA;
+    }
 }

--- a/src/Entity/Gebruiker.php
+++ b/src/Entity/Gebruiker.php
@@ -418,4 +418,98 @@ class Gebruiker implements UserInterface, \Serializable, AdvancedUserInterface, 
         }
         return true;
     }
+
+    /**
+     * Check if current user is part of a MaDi organisation, based on the following roles:
+     *     Gebruiker::TYPE_MADI,
+     *     Gebruiker::TYPE_MADI_KEYUSER,
+     *
+     * @return bool
+     */
+    public function isMadi(): bool
+    {
+        return in_array($this->getType(), [
+            self::TYPE_MADI,
+            self::TYPE_MADI_KEYUSER,
+        ], true);
+    }
+
+    /**
+     * Checks whether the user is a Madi Key User
+     * This check can be used to check if a user has access by having one of the following role:
+     *     Gebruiker::TYPE_MADI_KEYUSER,
+     *
+     * @return bool
+     */
+    public function isMadiKeyUser(): bool
+    {
+        return $this->getType() === self::TYPE_MADI_KEYUSER;
+    }
+
+    /**
+     * Check if current user is part of the Gka organisation, based on the following roles:
+     *     Gebruiker::TYPE_GKA,
+     *     Gebruiker::TYPE_GKA_APPBEHEERDER,
+     *
+     * @return bool
+     */
+    public function isGka(): bool
+    {
+        return in_array($this->getType(), [
+            self::TYPE_GKA,
+            self::TYPE_GKA_APPBEHEERDER,
+        ], true);
+    }
+    /**
+     * Checks whether the user is a GKA AppBeheerder
+     * This check can be used to check if a user has access by having one of the following role:
+     *     Gebruiker::TYPE_GKA_APPBEHEERDER,
+     *
+     * @return bool
+     */
+    public function isGkaAppBeheerder(): bool
+    {
+        return $this->getType() === self::TYPE_GKA_APPBEHEERDER;
+    }
+
+    /**
+     * Checks wether the user is either a Application Admin, a GKA Admin or a Madi Key User
+     * This check can be used to check if a user has access by having one of the following roles:
+     *     Gebruiker::TYPE_ADMIN,
+     *     Gebruiker::TYPE_GKA_APPBEHEEDER,
+     *     Gebruiker::TYPE_MADI_KEYUSER,
+     *
+     * @return bool
+     */
+    public function isGkaAppBeheerderOrMadiKeyUserOrApplicationAdmin(): bool
+    {
+        return in_array($this->getType(), [
+            self::TYPE_ADMIN,
+            self::TYPE_GKA_APPBEHEERDER,
+            self::TYPE_MADI_KEYUSER,
+        ], true);
+    }
+
+    /**
+     * Checks whether the user is a Application Admin
+     * This check can be used to check if a user has access by having one of the following role:
+     *     Gebruiker::TYPE_ADMIN,
+     * @return bool
+     */
+    public function isApplicationAdmin(): bool
+    {
+        return $this->getType() === self::TYPE_ADMIN;
+    }
+
+    /**
+     * Checks whether the user is unknown
+     * This check can be used to check if a user has access by having one of the following role:
+     *     Gebruiker::TYPE_ONBEKEND,
+     *
+     * @return bool
+     */
+    public function isUnknown(): bool
+    {
+        return $this->getType() === self::TYPE_ONBEKEND;
+    }
 }

--- a/src/Form/ChangeDossierStatusType.php
+++ b/src/Form/ChangeDossierStatusType.php
@@ -5,10 +5,18 @@ namespace GemeenteAmsterdam\FixxxSchuldhulp\Form;
 use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\DossierStatusFormType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * Class ChangeDossierStatusType
+ *
+ * @package GemeenteAmsterdam\FixxxSchuldhulp\Form
+ */
 class ChangeDossierStatusType extends AbstractType
 {
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -17,13 +25,4 @@ class ChangeDossierStatusType extends AbstractType
             ]);
 
     }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-//        $resolver->setDefaults([
-//
-//        ]);
-    }
 }
-
-

--- a/src/Form/ChangeDossierStatusType.php
+++ b/src/Form/ChangeDossierStatusType.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace GemeenteAmsterdam\FixxxSchuldhulp\Form;
+
+use GemeenteAmsterdam\FixxxSchuldhulp\Form\Type\DossierStatusFormType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ChangeDossierStatusType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('status', DossierStatusFormType::class, [
+                'label' => 'Wijzig status naar',
+            ]);
+
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+//        $resolver->setDefaults([
+//
+//        ]);
+    }
+}
+
+

--- a/src/Form/Type/DossierStatusFormType.php
+++ b/src/Form/Type/DossierStatusFormType.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GemeenteAmsterdam\FixxxSchuldhulp\Form\Type;
+
+use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Dossier;
+use GemeenteAmsterdam\FixxxSchuldhulp\Entity\Gebruiker;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class DossierStatusFormType extends AbstractType
+{
+    /**
+     * @var Gebruiker $user
+     */
+    private $user;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $token = $tokenStorage->getToken();
+        $this->user = $token->getUser();
+    }
+
+    /**
+     * @param OptionsResolver $resolver
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $choices = [];
+        switch ($this->user->getType()) {
+            case Gebruiker::TYPE_MADI_KEYUSER:
+                $choices = [
+                    'bezig_madi' => Dossier::STATUS_BEZIG_MADI,
+                    'compleet_madi' => Dossier::STATUS_COMPLEET_MADI,
+                    'gecontroleerd_madi' => Dossier::STATUS_GECONTROLEERD_MADI,
+                ];
+                break;
+            case Gebruiker::TYPE_GKA_APPBEHEERDER:
+                $choices = [
+                    'verzonden_madi' => Dossier::STATUS_VERZONDEN_MADI,
+                    'compleet_gka' => Dossier::STATUS_COMPLEET_GKA,
+                    'dossier_gecontroleerd_gka' => Dossier::STATUS_DOSSIER_GECONTROLEERD_GKA,
+                    'afgesloten_gka' => Dossier::STATUS_AFGESLOTEN_GKA,
+                ];
+                break;
+            case Gebruiker::TYPE_ADMIN:
+
+                $choices = [
+                    'bezig_madi' => Dossier::STATUS_BEZIG_MADI,
+                    'compleet_madi' => Dossier::STATUS_COMPLEET_MADI,
+                    'gecontroleerd_madi' => Dossier::STATUS_GECONTROLEERD_MADI,
+                    'verzonden_madi' => Dossier::STATUS_VERZONDEN_MADI,
+                    'compleet_gka' => Dossier::STATUS_COMPLEET_GKA,
+                    'dossier_gecontroleerd_gka' => Dossier::STATUS_DOSSIER_GECONTROLEERD_GKA,
+                    'afgesloten_gka' => Dossier::STATUS_AFGESLOTEN_GKA,
+                ];
+                break;
+        }
+
+
+        $resolver->setDefault('choices', $choices);
+        $resolver->setDefault('choice_translation_domain', true);
+        $resolver->setDefault('multiple', false);
+        $resolver->setDefault('expanded', false);
+        $resolver->setDefault('required', true);
+    }
+
+    /**
+     * @return string
+     */
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/templates/Dossier/detailVoorlegger.html.twig
+++ b/templates/Dossier/detailVoorlegger.html.twig
@@ -14,7 +14,6 @@
         {% include 'Dossier/partial.dossierHeader.html.twig' with {'dossier': dossier, 'active': 'aanvraag'} only %}
         {{ form_start(voorleggerForm, {'attr': {'id': 'voorlegger_form', 'data-submitter': 'save', 'data-result-selector': '.dossier__list-container', 'data-changer': 'change', 'novalidate':'novalidate'}}) }}
         {% if dossier.isInPrullenbak %}<h2 class="dossier__deleted__message">Dit dossier is verwijderd</h2>{% else %}<button type="submit" class="dossier__save button primary">Opslaan</button>{% endif %}
-        {{ form_errors(voorleggerForm) }}
         <div class="dossier__list-container">
             {% include 'Dossier/partial.dossierDashboard.html.twig' with {'dossier': dossier, 'changeDossierStatusForm': changeDossierStatusForm} only %}
             <div class="dossier__item__dummy active">

--- a/templates/Dossier/detailVoorlegger.html.twig
+++ b/templates/Dossier/detailVoorlegger.html.twig
@@ -16,7 +16,7 @@
         {% if dossier.isInPrullenbak %}<h2 class="dossier__deleted__message">Dit dossier is verwijderd</h2>{% else %}<button type="submit" class="dossier__save button primary">Opslaan</button>{% endif %}
         {{ form_errors(voorleggerForm) }}
         <div class="dossier__list-container">
-            {% include 'Dossier/partial.dossierDashboard.html.twig' with {'dossier': dossier} only %}
+            {% include 'Dossier/partial.dossierDashboard.html.twig' with {'dossier': dossier, 'changeDossierStatusForm': changeDossierStatusForm} only %}
             <div class="dossier__item__dummy active">
                 <div class="dossier__voorlegger__header dossier__voorlegger__header__top"><h3>Top</h3></div>
                 <div class="dossier__voorlegger__header dossier__voorlegger__header__bottom"><h3>Bottom</h3></div>

--- a/templates/Dossier/partial.dossierDashboard.html.twig
+++ b/templates/Dossier/partial.dossierDashboard.html.twig
@@ -61,7 +61,24 @@
                         {% include 'Dossier/partial.aantekening.html.twig' with {'aantekening': aantekening, 'showContext': true} %}
                     {% endfor %}
                 </div>
+
             </div>
         </div>
+        {% if dossier.isAfgesloten == FALSE and dossier.isInPrullenbak == FALSE %}
+            {% if app.user.isApplicationAdmin or (app.user.isMadiKeyUser and dossier.withMadi) or (app.user.isGkaAppBeheerder and dossier.withGka) %}
+                <div class="dossier__dashboard__controls">
+                    <div class="row">
+                        <h2>Dossier acties</h2>
+                    </div>
+                    <div class="row">
+                        <div class="col">
+                            <div class="dashboard_dossier_status_changer">
+                                {% include 'Dossier/partial.dossierStatusChanger.twig' %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        {% endif %}
     </div>
 </div>

--- a/templates/Dossier/partial.dossierDashboard.html.twig
+++ b/templates/Dossier/partial.dossierDashboard.html.twig
@@ -64,7 +64,7 @@
 
             </div>
         </div>
-        {% if dossier.isAfgesloten == FALSE and dossier.isInPrullenbak == FALSE %}
+        {% if dossier.isInPrullenbak == FALSE %}
             {% if app.user.isApplicationAdmin or (app.user.isMadiKeyUser and dossier.withMadi) or (app.user.isGkaAppBeheerder and dossier.withGka) %}
                 <div class="dossier__dashboard__controls">
                     <div class="row">

--- a/templates/Dossier/partial.dossierStatusChanger.twig
+++ b/templates/Dossier/partial.dossierStatusChanger.twig
@@ -1,0 +1,12 @@
+{% if changeDossierStatusForm != false %}
+    {{ form_start(changeDossierStatusForm) }}
+    <div class="dashboard_dossier_status_changer_element">
+        {{ form_label(changeDossierStatusForm.status) }}
+        <br>
+        {{ form_widget(changeDossierStatusForm.status) }}
+    </div>
+    <div class="dashboard_dossier_status_changer_element_errors">
+        {{ form_errors(changeDossierStatusForm.status) }}
+    </div>
+    {{ form_end(changeDossierStatusForm) }}
+{% endif %}

--- a/templates/Dossier/partial.dossierStatusChanger.twig
+++ b/templates/Dossier/partial.dossierStatusChanger.twig
@@ -3,7 +3,7 @@
     <div class="dashboard_dossier_status_changer_element">
         {{ form_label(changeDossierStatusForm.status) }}
         <br>
-        {{ form_widget(changeDossierStatusForm.status) }}
+        {{ form_widget(changeDossierStatusForm.status, {'attr': {'data-current': dossier.status}}) }}
     </div>
     <div class="dashboard_dossier_status_changer_element_errors">
         {{ form_errors(changeDossierStatusForm.status) }}


### PR DESCRIPTION
**Added dropdown for Madi Keyuser, Gka Appbeheerder and Admin to be able to change dossier to a certain status.**

Ik heb een stukje toegevoegd genaamd **Dossier Acties**. Hierin heb ik een dropdown ondergebracht waarmee een **Madi Keyuser**, **Gka Appbeheerder** en een **Admin** de status van een Dossier kunnen aanpassen.

Condities:
- Dossier Acties (met onderliggende elementen) wordt alleen getoond indien een dossier **NIET in de prullenbak is geplaatst**.
- Dropdown voor het wijzigen van een status wordt voor de **Madi** zijde alleen getoond indien de **ingelogde gebruiker van het type Madi Keyuser** is en het **dossier nog in behandeling is bij de Madi**.
- Een Madi kan alleen statussen aanpassen naar statussen binnen de Madi zelf, zie screenshot hieronder.
- Dropdown voor het wijzigen van een status wordt voor de **Gka** zijde alleen getoond indien de **ingelogde gebruiker van het type Gka Appbeheerder** is en het **dossier nog in behandeling is bij de Gka**.
- Een Gka kan alleen statussen aanpassen naar statussen binnen de Madi zelf, zie screenshot hieronder.
- Een Admin kan alles zien, en aanpassen.

Wat ziet een Madi Keyuser
![image](https://user-images.githubusercontent.com/4005934/53300259-10f68100-3845-11e9-926f-a0dc71d0836c.png)

Wat ziet een Gka Appbeheerder
![image](https://user-images.githubusercontent.com/4005934/53300266-2ec3e600-3845-11e9-8a04-4536b614cf2e.png)

Wat ziet een Admin:
![image](https://user-images.githubusercontent.com/4005934/53300275-5ca92a80-3845-11e9-9bc1-3af1a9a65396.png)

Extra:
Ik heb ook methods toegevoegd om te kunnen checken of een dossier bij de Madi of het Gka ligt. Tevens ook toegevoegd dat we snel/simpel kunnen checken of iemand een Madi of Gka persoon is. Daarbij ook voor het checken op eventuele Keyusers en Appbeheerders.

Openstaande issues:

- [ ] Bij het aanpassen van de status wordt de pagina niet volledig bijgewerkt.
