### PR TITLE
Download file with target blank

### DIFF
--- a/templates/partial.files-list.html.twig
+++ b/templates/partial.files-list.html.twig
@@ -13,7 +13,7 @@
                 {#{% if dossierDocument.document.origineleExtensie|lower == 'pdf' %}#}
                 <a href="{{ path('gemeenteamsterdam_fixxxschuldhulp_appdossier_detaildocument', {'dossierId': dossierDocument.dossier.id, 'documentId': dossierDocument.document.id}) }}"
                    class="bestand-zoom" title="Bekijk deze {{ dossierDocument.document.origineleExtensie|lower }}"
-                   data-handler="bestand">
+                   data-handler="bestand" target="_blank">
                     {#{{ dossierDocument.document.naam }}#}
                     <i class="icon-document"
                        data-extension="{{ dossierDocument.document.origineleExtensie|lower }}" {% if documentThumbnail is not empty %} data-decorator="lazy-load-document-thumb" data-background-image="{{ documentThumbnail }}" {% endif %}></i>


### PR DESCRIPTION
Some browsers ask to leave the page when clicking download in case there are unsaved changes. To prevent this, the download link is opened with target _blank