### PR TITLE
Use a more generic name for the Docker registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def tryStep(String message, Closure block, Closure tearDown = null) {
     }
 }
 
+String IMAGE_NAME = "${DOCKER_REGISTRY_NO_PROTOCOL}/fixxx/schuldhulp:${env.BUILD_NUMBER}"
 
 node {
     stage("Checkout") {
@@ -37,7 +38,7 @@ node {
             sh 'echo SOURCE_COMMIT := $commit_id >> .build'
             println commit_id
             echo 'end git version'
-            def image = docker.build("build.app.amsterdam.nl:5000/fixxx/schuldhulp:${env.BUILD_NUMBER}")
+            def image = docker.build("${IMAGE_NAME}")
             image.push()
 
         }
@@ -53,7 +54,7 @@ if (BRANCH == "master") {
     node {
         stage('Push acceptance image') {
             tryStep "image tagging", {
-                def image = docker.image("build.app.amsterdam.nl:5000/fixxx/schuldhulp:${env.BUILD_NUMBER}")
+                def image = docker.image("${IMAGE_NAME}")
                 image.pull()
                 image.push("acceptance")
                 image.push("production")
@@ -82,7 +83,7 @@ if (BRANCH == "master") {
     node {
         stage('Push production image') {
             tryStep "image tagging", {
-                def image = docker.image("build.app.amsterdam.nl:5000/fixxx/schuldhulp:${env.BUILD_NUMBER}")
+                def image = docker.image("${IMAGE_NAME}")
                 image.pull()
                 image.push("production")
                 image.push("latest")


### PR DESCRIPTION
By using a Jenkins env var we can have the same (or very similar) Jenkinsfiles in the 'secure' and 'master' branches.
This is to be merged into **master**.