### PR TITLE
Proper handling of access denied exception when not matching expected

### DIFF
--- a/src/Security/AccessDeniedHandler.php
+++ b/src/Security/AccessDeniedHandler.php
@@ -49,5 +49,7 @@ class AccessDeniedHandler implements AccessDeniedHandlerInterface
                 'message' => 'Gebruikerstype is onbekend. [' . $user->getEmail() . ']',
             ]), Response::HTTP_FORBIDDEN);
         }
+        
+        return new Response($accessDeniedException->getMessage(), Response::HTTP_FORBIDDEN);
     }
 }


### PR DESCRIPTION
type of access denied exception