### PR TITLE
SCHUL-165 - Opnieuw toevoegen beveiliging headers

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -60,6 +60,10 @@ nelmio_security:
         - 'self'
         - 'data:'
         - 'https://www.amsterdam.nl'
+      connect-src:
+        - 'self'
+        - 'https://www.amsterdam.nl'
+        - 'blob:'
       block-all-mixed-content: true # defaults to false, blocks HTTP content over HTTPS transport
       # upgrade-insecure-requests: true # defaults to false, upgrades HTTP requests to HTTPS transport
 


### PR DESCRIPTION
## Motivation and Context
- JIRA ticket: [SCHUL-165]([Insert ticket link])
<!-- Add additional links or files if applicable -->

## Description
Added nelmio security headers again after checking on ACC environment what went wrong.
Issie was the javascript being loaded using unsafe-eval. Added that to the allowlist

## Checklist
- [x] All the acceptance criteria are met
- [x] New or updated tests prove that the changes work and reflect the current business logic
- [x] Changes to the controllers are reflected in the documentation
- [x] Functionality has been manually tested on the server


[SCHUL-165]: https://gemeente-amsterdam.atlassian.net/browse/SCHUL-165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ