### PR TITLE
fix(schul-1024): network condig between phpfpm and nginx

### DIFF
--- a/docker-phpfpm/www.conf
+++ b/docker-phpfpm/www.conf
@@ -38,7 +38,7 @@ group = www-data
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = 127.0.0.1:9000
+listen = 0.0.0.0:9000
 
 ; Set listen(2) backlog.
 ; Default Value: 511 (-1 on Linux, FreeBSD and OpenBSD)


### PR DESCRIPTION
Solves 502 error on local and ACC probably on PROD when deploying. 

Error from log at nginx

> 2026/05/11 08:37:45 [error] 10#10: *4 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.0.5, server: schulddossier.amsterdam.nl, request: "GET / HTTP/1.1", upstream: "fastcgi://10.96.64.204:9000", host: "sd.local" 2026/05/11 08:37:45 [error] 10#10: *4 connect() failed (111: Connection refused) while connecting to upstream, client: 192.168.0.5, server: schulddossier.amsterdam.nl, request: "GET /favicon.ico HTTP/1.1", upstream: "fastcgi://10.96.64.204:9000", host: "sd.local", referrer: "https://sd.local/"